### PR TITLE
[winrt support] Adding macro to help check and test what API of the Windows Runtime is being used.

### DIFF
--- a/include/boost/predef/architecture/arm.h
+++ b/include/boost/predef/architecture/arm.h
@@ -1,6 +1,7 @@
 /*
 Copyright Rene Rivera 2008-2013
 Copyright Franz Detro 2014
+Copyright (c) Microsoft Corporation
 Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE_1_0.txt or copy at
 http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/predef/os/windows.h
+++ b/include/boost/predef/os/windows.h
@@ -1,5 +1,6 @@
 /*
 Copyright Rene Rivera 2008-2013
+Copyright (c) Microsoft Corporation
 Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE_1_0.txt or copy at
 http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
This change adds a macro BOOST_WINDOWS_RUNTIME that can be used by individual Boost libraries to determine which Windows APIs are available for use.

This is part of the work mentioned on the Boost dev mailing list to help get portions of Boost working in Windows store and phone.

http://boost.2283326.n4.nabble.com/winrt-support-Adding-support-for-Windows-8-store-phone-to-Boost-libraries-tc4661713.html

Originally I added this macro to Boost.Config but received feedback on the name and that it better belongs in Boost.Predef. For history here is the previous pull request from Boost.Config:
https://github.com/boostorg/config/pull/13
