### PR TITLE
Adding checking for _M_ARM macro for Windows.

### DIFF
--- a/include/boost/predef/architecture/arm.h
+++ b/include/boost/predef/architecture/arm.h
@@ -1,6 +1,7 @@
 /*
 Copyright Rene Rivera 2008-2013
 Copyright Franz Detro 2014
+Copyright (c) Microsoft Corporation 2014
 Distributed under the Boost Software License, Version 1.0.
 (See accompanying file LICENSE_1_0.txt or copy at
 http://www.boost.org/LICENSE_1_0.txt)
@@ -25,17 +26,20 @@ http://www.boost.org/LICENSE_1_0.txt)
     [[`__thumb__`] [__predef_detection__]]
     [[`__TARGET_ARCH_ARM`] [__predef_detection__]]
     [[`__TARGET_ARCH_THUMB`] [__predef_detection__]]
+    [[`_M_ARM'] [__predef_detection__]]
 
     [[`__arm64`] [8.0.0]]
     [[`__TARGET_ARCH_ARM`] [V.0.0]]
     [[`__TARGET_ARCH_THUMB`] [V.0.0]]
+    [[`_M_ARM`] [V.0.0]]
     ]
  */
 
 #define BOOST_ARCH_ARM BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
 #if defined(__arm__) || defined(__arm64) || defined(__thumb__) || \
-    defined(__TARGET_ARCH_ARM) || defined(__TARGET_ARCH_THUMB)
+    defined(__TARGET_ARCH_ARM) || defined(__TARGET_ARCH_THUMB) || \
+    defined(_M_ARM)
 #   undef BOOST_ARCH_ARM
 #   if !defined(BOOST_ARCH_ARM) && defined(__arm64)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(8,0,0)
@@ -45,6 +49,9 @@ http://www.boost.org/LICENSE_1_0.txt)
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && defined(__TARGET_ARCH_THUMB)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(__TARGET_ARCH_THUMB,0,0)
+#   endif
+#   if !defined(BOOST_ARCH_ARM) && defined(_M_ARM)
+#       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(_M_ARM,0,0)
 #   endif
 #   if !defined(BOOST_ARCH_ARM)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER_AVAILABLE


### PR DESCRIPTION
Broken down from part of previous pull request #3.

Incorporating feedback from Rene Rivera:
Updated the Microsoft copyright to include the year.
Made sure ARM predef uses version property with V.0.0.
