### PR TITLE
Fix clang warning (-Wundef)

### DIFF
--- a/include/boost/predef/os/aix.h
+++ b/include/boost/predef/os/aix.h
@@ -32,7 +32,7 @@ Version number available as major, minor, and patch.
 
 #define BOOST_OS_AIX BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(_AIX) || defined(__TOS_AIX__) \
     )
 #   undef BOOST_OS_AIX

--- a/include/boost/predef/os/amigaos.h
+++ b/include/boost/predef/os/amigaos.h
@@ -26,7 +26,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_AMIGAOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(AMIGA) || defined(__amigaos__) \
     )
 #   undef BOOST_OS_AMIGAOS

--- a/include/boost/predef/os/android.h
+++ b/include/boost/predef/os/android.h
@@ -25,7 +25,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_ANDROID BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__ANDROID__) \
     )
 #   undef BOOST_OS_ANDROID

--- a/include/boost/predef/os/beos.h
+++ b/include/boost/predef/os/beos.h
@@ -25,7 +25,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_BEOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__BEOS__) \
     )
 #   undef BOOST_OS_BEOS

--- a/include/boost/predef/os/bsd.h
+++ b/include/boost/predef/os/bsd.h
@@ -59,7 +59,7 @@ of BSD. If the above variants is detected the corresponding macro is also set.]
 #define BOOST_OS_BSD BOOST_VERSION_NUMBER_NOT_AVAILABLE
 #endif
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(BSD) || \
     defined(_SYSTYPE_BSD) \
     )

--- a/include/boost/predef/os/bsd/bsdi.h
+++ b/include/boost/predef/os/bsd/bsdi.h
@@ -24,7 +24,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_BSD_BSDI BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__bsdi__) \
     )
 #   ifndef BOOST_OS_BSD_AVAILABLE

--- a/include/boost/predef/os/bsd/dragonfly.h
+++ b/include/boost/predef/os/bsd/dragonfly.h
@@ -24,7 +24,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_BSD_DRAGONFLY BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__DragonFly__) \
     )
 #   ifndef BOOST_OS_BSD_AVAILABLE

--- a/include/boost/predef/os/bsd/free.h
+++ b/include/boost/predef/os/bsd/free.h
@@ -26,7 +26,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_BSD_FREE BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__FreeBSD__) \
     )
 #   ifndef BOOST_OS_BSD_AVAILABLE

--- a/include/boost/predef/os/bsd/net.h
+++ b/include/boost/predef/os/bsd/net.h
@@ -31,7 +31,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_BSD_NET BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__NETBSD__) || defined(__NetBSD__) \
     )
 #   ifndef BOOST_OS_BSD_AVAILABLE

--- a/include/boost/predef/os/bsd/open.h
+++ b/include/boost/predef/os/bsd/open.h
@@ -55,7 +55,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_BSD_OPEN BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__OpenBSD__) \
     )
 #   ifndef BOOST_OS_BSD_AVAILABLE

--- a/include/boost/predef/os/cygwin.h
+++ b/include/boost/predef/os/cygwin.h
@@ -25,7 +25,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_CYGWIN BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__CYGWIN__) \
     )
 #   undef BOOST_OS_CYGWIN

--- a/include/boost/predef/os/hpux.h
+++ b/include/boost/predef/os/hpux.h
@@ -27,7 +27,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_HPUX BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(hpux) || defined(_hpux) || defined(__hpux) \
     )
 #   undef BOOST_OS_HPUX

--- a/include/boost/predef/os/ios.h
+++ b/include/boost/predef/os/ios.h
@@ -29,7 +29,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_IOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__APPLE__) && defined(__MACH__) && \
     defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) \
     )

--- a/include/boost/predef/os/irix.h
+++ b/include/boost/predef/os/irix.h
@@ -26,7 +26,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_IRIX BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(sgi) || defined(__sgi) \
     )
 #   undef BOOST_OS_IRIX

--- a/include/boost/predef/os/linux.h
+++ b/include/boost/predef/os/linux.h
@@ -26,7 +26,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_LINUX BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(linux) || defined(__linux) \
     )
 #   undef BOOST_OS_LINUX

--- a/include/boost/predef/os/macos.h
+++ b/include/boost/predef/os/macos.h
@@ -39,7 +39,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_MACOS BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(macintosh) || defined(Macintosh) || \
     (defined(__APPLE__) && defined(__MACH__)) \
     )

--- a/include/boost/predef/os/os400.h
+++ b/include/boost/predef/os/os400.h
@@ -25,7 +25,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_OS400 BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__OS400__) \
     )
 #   undef BOOST_OS_OS400

--- a/include/boost/predef/os/qnxnto.h
+++ b/include/boost/predef/os/qnxnto.h
@@ -31,7 +31,7 @@ version 4 is specifically detected.
 
 #define BOOST_OS_QNX BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(__QNX__) || defined(__QNXNTO__) \
     )
 #   undef BOOST_OS_QNX

--- a/include/boost/predef/os/solaris.h
+++ b/include/boost/predef/os/solaris.h
@@ -26,7 +26,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_SOLARIS BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(sun) || defined(__sun) \
     )
 #   undef BOOST_OS_SOLARIS

--- a/include/boost/predef/os/unix.h
+++ b/include/boost/predef/os/unix.h
@@ -28,7 +28,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_UNIX BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(unix) || defined(__unix) || \
     defined(_XOPEN_SOURCE) || defined(_POSIX_SOURCE) \
     )

--- a/include/boost/predef/os/vms.h
+++ b/include/boost/predef/os/vms.h
@@ -28,7 +28,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_VMS BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(VMS) || defined(__VMS) \
     )
 #   undef BOOST_OS_VMS

--- a/include/boost/predef/os/windows.h
+++ b/include/boost/predef/os/windows.h
@@ -29,7 +29,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_OS_WINDOWS BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
-#if !BOOST_PREDEF_DETAIL_OS_DETECTED && ( \
+#if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
     defined(_WIN32) || defined(_WIN64) || \
     defined(__WIN32__) || defined(__TOS_WIN__) || \
     defined(__WINDOWS__) \


### PR DESCRIPTION
Since macro BOOST_PREDEF_DETAIL_OS_DETECTED used before initialization it
must be checked with `#if !defined(` command instead of `#if !(`.
