### PR TITLE
Fix SIMD x86 predef redefinition (on AMD cpus) and fix doc

### DIFF
--- a/include/boost/predef/hardware/simd.h
+++ b/include/boost/predef/hardware/simd.h
@@ -77,12 +77,24 @@ http://www.boost.org/LICENSE_1_0.txt)
 #   error "Multiple SIMD architectures detected, this cannot happen!"
 #endif
 
-#if defined(BOOST_HW_SIMD_X86_AVAILABLE)
-#   define BOOST_HW_SIMD BOOST_HW_SIMD_X86
+#if defined(BOOST_HW_SIMD_X86_AVAILABLE) && defined(BOOST_HW_SIMD_X86_AMD_AVAILABLE)
+    // If both standard _X86 and _X86_AMD are available,
+    // then take the biggest version of the two!
+#   if BOOST_HW_SIMD_X86 >= BOOST_HW_SIMD_X86_AMD
+#      define BOOST_HW_SIMD BOOST_HW_SIMD_X86
+#   else
+#      define BOOST_HW_SIMD BOOST_HW_SIMD_X86_AMD
+#   endif
 #endif
 
-#if defined(BOOST_HW_SIMD_X86_AMD_AVAILABLE)
-#   define BOOST_HW_SIMD BOOST_HW_SIMD_X86_AMD
+#if !defined(BOOST_HW_SIMD)
+    // At this point, only one of these two is defined
+#   if defined(BOOST_HW_SIMD_X86_AVAILABLE)
+#      define BOOST_HW_SIMD BOOST_HW_SIMD_X86
+#   endif
+#   if defined(BOOST_HW_SIMD_X86_AMD_AVAILABLE)
+#      define BOOST_HW_SIMD BOOST_HW_SIMD_X86_AMD
+#   endif
 #endif
 
 #if defined(BOOST_HW_SIMD_ARM_AVAILABLE)

--- a/include/boost/predef/hardware/simd/x86.h
+++ b/include/boost/predef/hardware/simd/x86.h
@@ -67,7 +67,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
      [[`__FMA__`] [BOOST_HW_SIMD_X86_FMA3_VERSION]]
 
-     [[`__AVX2__`] [BOOST_HW_SIMD_x86_AVX2_VERSION]]
+     [[`__AVX2__`] [BOOST_HW_SIMD_X86_AVX2_VERSION]]
      ]
 
  */

--- a/include/boost/predef/hardware/simd/x86_amd.h
+++ b/include/boost/predef/hardware/simd/x86_amd.h
@@ -33,13 +33,13 @@ http://www.boost.org/LICENSE_1_0.txt)
  [table
      [[__predef_symbol__] [__predef_version__]]
 
-     [[`__SSE4A__`] [BOOST_HW_SIMD_x86_SSE4A_VERSION]]
+     [[`__SSE4A__`] [BOOST_HW_SIMD_X86_SSE4A_VERSION]]
 
-     [[`__FMA4__`] [BOOST_HW_SIMD_x86_FMA4_VERSION]]
+     [[`__FMA4__`] [BOOST_HW_SIMD_X86_FMA4_VERSION]]
 
-     [[`__XOP__`] [BOOST_HW_SIMD_x86_XOP_VERSION]]
+     [[`__XOP__`] [BOOST_HW_SIMD_X86_XOP_VERSION]]
 
-     [[`BOOST_HW_SIMD_X86`] [BOOST_HW_SIMD_x86]]
+     [[`BOOST_HW_SIMD_X86`] [BOOST_HW_SIMD_X86]]
      ]
 
  [note This predef includes every other x86 SIMD extensions and also has other

--- a/include/boost/predef/hardware/simd/x86_amd/versions.h
+++ b/include/boost/predef/hardware/simd/x86_amd/versions.h
@@ -30,9 +30,9 @@ http://www.boost.org/LICENSE_1_0.txt)
 #define BOOST_HW_SIMD_X86_AMD_SSE4A_VERSION BOOST_VERSION_NUMBER(4, 0, 0)
 
 /*`
- [heading `BOOST_HW_SIMD_X86_XOP_VERSION`]
+ [heading `BOOST_HW_SIMD_X86_FMA4_VERSION`]
 
- [@https://en.wikipedia.org/wiki/XOP_instruction_set XOP] x86 extension (AMD specific).
+ [@https://en.wikipedia.org/wiki/FMA_instruction_set#FMA4_instruction_set FMA4] x86 extension (AMD specific).
 
  Version number is: *5.1.0*.
  */


### PR DESCRIPTION
I've noticed that `BOOST_HW_SIMD` was redefined when AMD SIMD extensions were detected. For example:

```c++
#include <boost/predef.h>
#include <iostream>

int main() {
  std::cout << BOOST_HW_SIMD << std::endl;
  return 0;
}
```

Using this command line (on a machine with an AMD cpu):
```shell
g++ -mxop -mavx2 main.cpp -I predef/include/ && ./a.out
```

Was giving this warning:
```shell
In file included from predef/include/boost/predef/hardware.h:14:0,
                 from predef/include/boost/predef.h:20,
                 from main.cpp:1:
predef/include/boost/predef/hardware/simd.h:85:0: warning: "BOOST_HW_SIMD" redefined [enabled by default]
predef/include/boost/predef/hardware/simd.h:81:0: note: this is the location of the previous definition
50300000
```

I've also found some part of the documentation that were wrong... For example: `_X86` was `_x86` in some predef names (only in the documentation) and also some heading were invalid.

Let me know if something is wrong with that PR. Thanks!