### PR TITLE
Fix XSL boost root path.

### DIFF
--- a/doc/build.jam
+++ b/doc/build.jam
@@ -48,7 +48,7 @@ boostbook standalone
     :
         predef
     :
-        <xsl:param>boost.root=../../..
+        <xsl:param>boost.root=../../../..
         #<xsl:param>generate.section.toc.level=3
         <xsl:param>chunk.section.depth=2
         <xsl:param>chunk.first.sections=1


### PR DESCRIPTION
When the Predef local docs are generated for release links, images, css looks missing because the boost.root doesn't go far enough up the hierarchy.