### PR TITLE
Fix SIMD documentation for AMD family

### DIFF
--- a/include/boost/predef/hardware/simd/x86_amd/versions.h
+++ b/include/boost/predef/hardware/simd/x86_amd/versions.h
@@ -21,7 +21,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 // ---------------------------------
 
 /*`
- [heading `BOOST_HW_SIMD_X86_SSE4A_VERSION`]
+ [heading `BOOST_HW_SIMD_X86_AMD_SSE4A_VERSION`]
 
  [@https://en.wikipedia.org/wiki/SSE4##SSE4A SSE4A] x86 extension (AMD specific).
 
@@ -30,7 +30,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 #define BOOST_HW_SIMD_X86_AMD_SSE4A_VERSION BOOST_VERSION_NUMBER(4, 0, 0)
 
 /*`
- [heading `BOOST_HW_SIMD_X86_FMA4_VERSION`]
+ [heading `BOOST_HW_SIMD_X86_AMD_FMA4_VERSION`]
 
  [@https://en.wikipedia.org/wiki/FMA_instruction_set#FMA4_instruction_set FMA4] x86 extension (AMD specific).
 
@@ -39,7 +39,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 #define BOOST_HW_SIMD_X86_AMD_FMA4_VERSION BOOST_VERSION_NUMBER(5, 1, 0)
 
 /*`
- [heading `BOOST_HW_SIMD_X86_XOP_VERSION`]
+ [heading `BOOST_HW_SIMD_X86_AMD_XOP_VERSION`]
 
  [@https://en.wikipedia.org/wiki/XOP_instruction_set XOP] x86 extension (AMD specific).
 


### PR DESCRIPTION
The `_AMD` was missing from their names.