### PR TITLE
Adds support for MSVC ARM64 target.

### DIFF
--- a/include/boost/predef/architecture/arm.h
+++ b/include/boost/predef/architecture/arm.h
@@ -27,11 +27,13 @@ http://www.boost.org/LICENSE_1_0.txt)
     [[`__TARGET_ARCH_ARM`] [__predef_detection__]]
     [[`__TARGET_ARCH_THUMB`] [__predef_detection__]]
     [[`_M_ARM`] [__predef_detection__]]
+    [[`_M_ARM64`] [__predef_detection__]]
 
     [[`__arm64`] [8.0.0]]
     [[`__TARGET_ARCH_ARM`] [V.0.0]]
     [[`__TARGET_ARCH_THUMB`] [V.0.0]]
     [[`_M_ARM`] [V.0.0]]
+    [[`_M_ARM64`] [8.0.0]]
     ]
  */
 
@@ -39,7 +41,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #if defined(__arm__) || defined(__arm64) || defined(__thumb__) || \
     defined(__TARGET_ARCH_ARM) || defined(__TARGET_ARCH_THUMB) || \
-    defined(_M_ARM)
+    defined(_M_ARM) || defined(_M_ARM64)
 #   undef BOOST_ARCH_ARM
 #   if !defined(BOOST_ARCH_ARM) && defined(__arm64)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(8,0,0)
@@ -49,6 +51,9 @@ http://www.boost.org/LICENSE_1_0.txt)
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && defined(__TARGET_ARCH_THUMB)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(__TARGET_ARCH_THUMB,0,0)
+#   endif
+#   if !defined(BOOST_ARCH_ARM) && defined(_M_ARM64)
+#       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(8,0,0)
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && defined(_M_ARM)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(_M_ARM,0,0)

--- a/include/boost/predef/hardware/simd/arm.h
+++ b/include/boost/predef/hardware/simd/arm.h
@@ -24,6 +24,7 @@ http://www.boost.org/LICENSE_1_0.txt)
      [[`__ARM_NEON__`] [__predef_detection__]]
      [[`__aarch64__`] [__predef_detection__]]
      [[`_M_ARM`] [__predef_detection__]]
+     [[`_M_ARM64`] [__predef_detection__]]
      ]
 
  [table
@@ -32,6 +33,7 @@ http://www.boost.org/LICENSE_1_0.txt)
      [[`__ARM_NEON__`] [BOOST_HW_SIMD_ARM_NEON_VERSION]]
      [[`__aarch64__`] [BOOST_HW_SIMD_ARM_NEON_VERSION]]
      [[`_M_ARM`] [BOOST_HW_SIMD_ARM_NEON_VERSION]]
+     [[`_M_ARM64`] [BOOST_HW_SIMD_ARM_NEON_VERSION]]
      ]
 
  */
@@ -39,7 +41,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 #define BOOST_HW_SIMD_ARM BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
 #undef BOOST_HW_SIMD_ARM
-#if !defined(BOOST_HW_SIMD_ARM) && (defined(__ARM_NEON__) || defined(__aarch64__) || defined (_M_ARM))
+#if !defined(BOOST_HW_SIMD_ARM) && (defined(__ARM_NEON__) || defined(__aarch64__) || defined (_M_ARM) || defined (_M_ARM64))
 #   define BOOST_HW_SIMD_ARM BOOST_HW_SIMD_ARM_NEON_VERSION
 #endif
 


### PR DESCRIPTION
Use the predefined macro _M_ARM64 in VS2015+ to detect ARM64 target.