### PR TITLE
isolate all headers to ensure that none rely on inclusions from another

### DIFF
--- a/test/build.jam
+++ b/test/build.jam
@@ -46,9 +46,37 @@ project predef-test
         <dependency>$(predef-dependency)
     ;
 
+import path ;
+import regex ;
 using testing ;
 
+# this rule enumerates through all the headers and ensures
+# that inclusion of the header by itself is sufficient to
+# compile successfully, proving the header does not depend
+# on any other headers to be included first - adapted from
+# logic in the winapi test bjam script
+rule test_all_headers_isolated
+{
+    local all_rules = ;
+    local file ;
+    local headers_path = [ path.make $(BOOST_ROOT)/libs/predef/include/boost/predef ] ;
+    for file in [ path.glob-tree $(headers_path) : *.h* : predef ]
+    {
+        local rel_file = [ path.relative-to $(headers_path) $(file) ] ;
+        # Note: The test name starts with '~' in order to group these tests in the test report table, preferably at the end.
+        #       All '/' are replaced with '-' because apparently test scripts have a problem with test names containing slashes.
+        local test_name = [ regex.replace $(rel_file) "/" "-" ] ;
+        local decl_test_name = ~hdr-decl-$(test_name) ;
+        # ECHO $(rel_file) ;
+        all_rules += [ compile compile/decl_header.cpp : <define>"BOOST_PREDEF_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(decl_test_name) ] ;
+    }
+
+    # ECHO All rules: $(all_rules) ;
+    return $(all_rules) ;
+}
+
 test-suite predef :
+    [ test_all_headers_isolated ]
     [ run info_as_cpp.cpp : : : <test-info>always_show_run_output ]
     [ run info_as_c.c : : : <test-info>always_show_run_output ]
     [ run info_as_objcpp.mm : : : <test-info>always_show_run_output ]

--- a/test/compile/decl_header.cpp
+++ b/test/compile/decl_header.cpp
@@ -1,0 +1,24 @@
+/*
+ *             Copyright Andrey Semashev 2015.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   decl_header.cpp
+ * \author Andrey Semashev
+ * \date   21.06.2015
+ *
+ * \brief  This file contains a test boilerplate for checking that every
+ *         public header is self-contained and does not have any missing
+ *         #includes.
+ */
+
+#define BOOST_PREDEF_TEST_INCLUDE_HEADER() <boost/predef/BOOST_PREDEF_TEST_HEADER>
+
+#include BOOST_PREDEF_TEST_INCLUDE_HEADER()
+
+int main(int, char*[])
+{
+    return 0;
+}


### PR DESCRIPTION
This uses a bjam technique from winapi that @lastique came up with.