### PR TITLE
Detect mingw and mingw64 as separate platforms

### DIFF
--- a/include/boost/predef/platform.h
+++ b/include/boost/predef/platform.h
@@ -12,6 +12,8 @@ http://www.boost.org/LICENSE_1_0.txt)
 #endif
 
 #include <boost/predef/platform/mingw.h>
+#include <boost/predef/platform/mingw32.h>
+#include <boost/predef/platform/mingw64.h>
 #include <boost/predef/platform/windows_uwp.h>
 #include <boost/predef/platform/windows_desktop.h>
 #include <boost/predef/platform/windows_phone.h>

--- a/include/boost/predef/platform/mingw.h
+++ b/include/boost/predef/platform/mingw.h
@@ -14,7 +14,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_MINGW`]
 
-[@http://en.wikipedia.org/wiki/MinGW MinGW] platform.
+[@http://en.wikipedia.org/wiki/MinGW MinGW] platform, either variety.
 Version number available as major, minor, and patch.
 
 [table
@@ -56,7 +56,7 @@ Version number available as major, minor, and patch.
 #   include <boost/predef/detail/platform_detected.h>
 #endif
 
-#define BOOST_PLAT_MINGW_NAME "MinGW"
+#define BOOST_PLAT_MINGW_NAME "MinGW (any variety)"
 
 #endif
 

--- a/include/boost/predef/platform/mingw32.h
+++ b/include/boost/predef/platform/mingw32.h
@@ -1,0 +1,63 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_PLAT_MINGW32_H
+#define BOOST_PREDEF_PLAT_MINGW32_H
+
+#include <boost/predef/version_number.h>
+#include <boost/predef/make.h>
+
+/*`
+[heading `BOOST_PLAT_MINGW32`]
+
+[@http://www.mingw.org/ MinGW] platform.
+Version number available as major, minor, and patch.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__MINGW32__`] [__predef_detection__]]
+
+    [[`__MINGW32_VERSION_MAJOR`, `__MINGW32_VERSION_MINOR`] [V.R.0]]
+    ]
+ */
+
+#define BOOST_PLAT_MINGW32 BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if defined(__MINGW32__)
+#   include <_mingw.h>
+#   if !defined(BOOST_PLAT_MINGW32_DETECTION) && (defined(__MINGW32_VERSION_MAJOR) && defined(__MINGW32_VERSION_MINOR))
+#       define BOOST_PLAT_MINGW32_DETECTION \
+            BOOST_VERSION_NUMBER(__MINGW32_VERSION_MAJOR,__MINGW32_VERSION_MINOR,0)
+#   endif
+#   if !defined(BOOST_PLAT_MINGW32_DETECTION)
+#       define BOOST_PLAT_MINGW32_DETECTION BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#ifdef BOOST_PLAT_MINGW32_DETECTION
+#   define BOOST_PLAT_MINGW32_AVAILABLE
+#   if defined(BOOST_PREDEF_DETAIL_PLAT_DETECTED)
+#       define BOOST_PLAT_MINGW32_EMULATED BOOST_PLAT_MINGW32_DETECTION
+#   else
+#       undef BOOST_PLAT_MINGW32
+#       define BOOST_PLAT_MINGW32 BOOST_PLAT_MINGW32_DETECTION
+#   endif
+#   include <boost/predef/detail/platform_detected.h>
+#endif
+
+#define BOOST_PLAT_MINGW32_NAME "MinGW"
+
+#endif
+
+#include <boost/predef/detail/test.h>
+BOOST_PREDEF_DECLARE_TEST(BOOST_PLAT_MINGW32,BOOST_PLAT_MINGW32_NAME)
+
+#ifdef BOOST_PLAT_MINGW32_EMULATED
+#include <boost/predef/detail/test.h>
+BOOST_PREDEF_DECLARE_TEST(BOOST_PLAT_MINGW32_EMULATED,BOOST_PLAT_MINGW32_NAME)
+#endif

--- a/include/boost/predef/platform/mingw64.h
+++ b/include/boost/predef/platform/mingw64.h
@@ -1,0 +1,63 @@
+/*
+Copyright Rene Rivera 2008-2015
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_PLAT_MINGW64_H
+#define BOOST_PREDEF_PLAT_MINGW64_H
+
+#include <boost/predef/version_number.h>
+#include <boost/predef/make.h>
+
+/*`
+[heading `BOOST_PLAT_MINGW64`]
+
+[@https://mingw-w64.org/ MinGW-w64] platform.
+Version number available as major, minor, and patch.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__MINGW64__`] [__predef_detection__]]
+
+    [[`__MINGW64_VERSION_MAJOR`, `__MINGW64_VERSION_MINOR`] [V.R.0]]
+    ]
+ */
+
+#define BOOST_PLAT_MINGW64 BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if defined(__MINGW64__)
+#   include <_mingw.h>
+#   if !defined(BOOST_PLAT_MINGW64_DETECTION) && (defined(__MINGW64_VERSION_MAJOR) && defined(__MINGW64_VERSION_MINOR))
+#       define BOOST_PLAT_MINGW64_DETECTION \
+            BOOST_VERSION_NUMBER(__MINGW64_VERSION_MAJOR,__MINGW64_VERSION_MINOR,0)
+#   endif
+#   if !defined(BOOST_PLAT_MINGW64_DETECTION)
+#       define BOOST_PLAT_MINGW64_DETECTION BOOST_VERSION_NUMBER_AVAILABLE
+#   endif
+#endif
+
+#ifdef BOOST_PLAT_MINGW64_DETECTION
+#   define BOOST_PLAT_MINGW64_AVAILABLE
+#   if defined(BOOST_PREDEF_DETAIL_PLAT_DETECTED)
+#       define BOOST_PLAT_MINGW64_EMULATED BOOST_PLAT_MINGW64_DETECTION
+#   else
+#       undef BOOST_PLAT_MINGW64
+#       define BOOST_PLAT_MINGW64 BOOST_PLAT_MINGW64_DETECTION
+#   endif
+#   include <boost/predef/detail/platform_detected.h>
+#endif
+
+#define BOOST_PLAT_MINGW64_NAME "MinGW-w64"
+
+#endif
+
+#include <boost/predef/detail/test.h>
+BOOST_PREDEF_DECLARE_TEST(BOOST_PLAT_MINGW64,BOOST_PLAT_MINGW64_NAME)
+
+#ifdef BOOST_PLAT_MINGW64_EMULATED
+#include <boost/predef/detail/test.h>
+BOOST_PREDEF_DECLARE_TEST(BOOST_PLAT_MINGW64_EMULATED,BOOST_PLAT_MINGW64_NAME)
+#endif


### PR DESCRIPTION
They are different distributions with different capabilities and should be detected separately.

The definition of ``BOOST_PLAT_MINGW`` is still the same as before: available if the compile is under MinGW or MinGW-w64.

Two new definitions were added, ``BOOST_PLAT_MINGW32`` and ``BOOST_PLAT_MINGW64`` which specifically detect either respectively.  This maintains backwards compatibility, and I didn't deprecate anything.