### PR TITLE
fix typo s/BOOST_ARCH_PARISK/BOOST_ARCH_PARISC

### DIFF
--- a/include/boost/predef/architecture/parisc.h
+++ b/include/boost/predef/architecture/parisc.h
@@ -12,7 +12,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/predef/make.h>
 
 /*`
-[heading `BOOST_ARCH_PARISK`]
+[heading `BOOST_ARCH_PARISC`]
 
 [@http://en.wikipedia.org/wiki/PA-RISC_family HP/PA RISC] architecture.
 


### PR DESCRIPTION
In predef/architecture/parisc.h:15 has been described as 'BOOST_ARCH_PARIS**K**'. However, in actual fact, it is 'BOOST_ARCH_PARIS**C**'.