### PR TITLE
make BOOST_PLAT_WINDOWS_DESKTOP available in older SDKs for backwards compatibility

### DIFF
--- a/include/boost/predef/platform/windows_desktop.h
+++ b/include/boost/predef/platform/windows_desktop.h
@@ -17,21 +17,23 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_WINDOWS_DESKTOP`]
 
-BOOST_PLAT_WINDOWS_DESKTOP is available if the Platform SDK supports UWP development
-with the DESKTOP family, and WINAPI_FAMILY is set to WINAPI_FAMILY_DESKTOP_APP.
+[@https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide UWP]
+for Windows Desktop development.  Also available if the Platform SDK is too
+old to support UWP.
 
 [table
     [[__predef_symbol__] [__predef_version__]]
 
-    [[`WINAPI_FAMILY_DESKTOP_APP`] [__predef_detection__]]
     [[`WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP`] [__predef_detection__]]
+    [[`!BOOST_PLAT_WINDOWS_UWP`] [__predef_detection__]]
     ]
  */
 
 #define BOOST_PLAT_WINDOWS_DESKTOP BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
 #if BOOST_OS_WINDOWS && \
-    defined(WINAPI_FAMILY_DESKTOP_APP) && WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP
+    ((defined(WINAPI_FAMILY_DESKTOP_APP) && WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP) || \
+     !BOOST_PLAT_WINDOWS_UWP)
 #   undef BOOST_PLAT_WINDOWS_DESKTOP
 #   define BOOST_PLAT_WINDOWS_DESKTOP BOOST_VERSION_NUMBER_AVAILABLE
 #endif

--- a/include/boost/predef/platform/windows_phone.h
+++ b/include/boost/predef/platform/windows_phone.h
@@ -17,13 +17,12 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_WINDOWS_PHONE`]
 
-BOOST_PLAT_WINDOWS_PHONE is available if the Platform SDK supports UWP development
-with the PHONE family, and WINAPI_FAMILY is set to WINAPI_FAMILY_PHONE_APP.
+[@https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide UWP]
+for Windows Phone development.
 
 [table
     [[__predef_symbol__] [__predef_version__]]
 
-    [[`WINAPI_FAMILY_PHONE_APP`] [__predef_detection__]]
     [[`WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP`] [__predef_detection__]]
     ]
  */

--- a/include/boost/predef/platform/windows_runtime.h
+++ b/include/boost/predef/platform/windows_runtime.h
@@ -18,11 +18,11 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_WINDOWS_RUNTIME`]
 
-This is deprecated.  Consumers should switch to use:
+Deprecated.
 
-    `BOOST_PLAT_WINDOWS_PHONE || BOOST_PLAT_WINDOWS_STORE`
-
-to detect a non-desktop UWP target.
+[@https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide UWP]
+for Windows Phone or Store development.  This does not align to the existing development model for
+UWP and is deprecated.  Use one of the other `BOOST_PLAT_WINDOWS_*`definitions instead.
 
 [table
     [[__predef_symbol__] [__predef_version__]]

--- a/include/boost/predef/platform/windows_server.h
+++ b/include/boost/predef/platform/windows_server.h
@@ -16,13 +16,12 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_WINDOWS_SERVER`]
 
-BOOST_PLAT_WINDOWS_SERVER is available if the Platform SDK supports UWP development
-with the SERVER family, and WINAPI_FAMILY is set to WINAPI_FAMILY_SERVER_APP.
+[@https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide UWP]
+for Windows Server development.
 
 [table
     [[__predef_symbol__] [__predef_version__]]
 
-    [[`WINAPI_FAMILY_SERVER`] [__predef_detection__]]
     [[`WINAPI_FAMILY == WINAPI_FAMILY_SERVER`] [__predef_detection__]]
     ]
  */

--- a/include/boost/predef/platform/windows_store.h
+++ b/include/boost/predef/platform/windows_store.h
@@ -17,6 +17,9 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_WINDOWS_STORE`]
 
+[@https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide UWP]
+for Windows Store development.
+
 [table
     [[__predef_symbol__] [__predef_version__]]
 

--- a/include/boost/predef/platform/windows_system.h
+++ b/include/boost/predef/platform/windows_system.h
@@ -16,13 +16,12 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_WINDOWS_SYSTEM`]
 
-BOOST_PLAT_WINDOWS_SYSTEM is available if the Platform SDK supports UWP development
-with the SYSTEM family, and WINAPI_FAMILY is set to WINAPI_FAMILY_SYSTEM_APP.
+[@https://docs.microsoft.com/en-us/windows/uwp/get-started/universal-application-platform-guide UWP]
+for Windows System development.
 
 [table
     [[__predef_symbol__] [__predef_version__]]
 
-    [[`WINAPI_FAMILY_SYSTEM`] [__predef_detection__]]
     [[`WINAPI_FAMILY == WINAPI_FAMILY_SYSTEM`] [__predef_detection__]]
     ]
  */

--- a/include/boost/predef/platform/windows_uwp.h
+++ b/include/boost/predef/platform/windows_uwp.h
@@ -15,21 +15,9 @@ http://www.boost.org/LICENSE_1_0.txt)
 /*`
 [heading `BOOST_PLAT_WINDOWS_UWP`]
 
-[@http://docs.microsoft.com/windows/uwp/ Universal Windows Platform].
-BOOST_PLAT_WINDOWS_UWP is available if the current development environment
-is capable of targeting Universal Windows Platform development.  To target
-a specific family one would define WINAPI_FAMILY, and in a UWP-capable
-environment this may limit the Win32 APIs available to achieve portability.
-
-To detect Windows API availability that is backwards compatible to pre-UWP SDKs, use:
-    `#if !BOOST_PLAT_WINDOWS_UWP || BOOST_PLAT_WINDOWS_DESKTOP`
-
-To detect Windows API availability in a specific UWP family, for example SYSTEM:
-    `#if BOOST_PLAT_WINDOWS_SYSTEM`
-
-UWP development is available on:
-  - Microsoft Windows SDK 8.0 or later
-  - MinGW-w64 version 3.0 or later
+[@http://docs.microsoft.com/windows/uwp/ Universal Windows Platform]
+is available if the current development environment is capable of targeting 
+UWP development.
 
 [table
     [[__predef_symbol__] [__predef_version__]]

--- a/test/platform_windows.cpp
+++ b/test/platform_windows.cpp
@@ -31,11 +31,12 @@ http://www.boost.org/LICENSE_1_0.txt)
 #if !BOOST_PLAT_WINDOWS_UWP
 
 //
-// If BOOST_PLAT_WINDOWS_UWP not available, none of the other BOOST_PLAT_WINDOWS_* are either
+// If BOOST_PLAT_WINDOWS_UWP is not available, none of the other BOOST_PLAT_WINDOWS_* are either
+// except for BOOST_PLAT_WINDOWS_DESKTOP which is available for backwards compatibility.
 //
 
-#if BOOST_PLAT_WINDOWS_DESKTOP
-#error "BOOST_PLAT_WINDOWS_DESKTOP should not be available"
+#if BOOST_OS_WINDOWS && !BOOST_PLAT_WINDOWS_DESKTOP
+#error "BOOST_PLAT_WINDOWS_DESKTOP should be available"
 #endif
 #if BOOST_PLAT_WINDOWS_PHONE
 #error "BOOST_PLAT_WINDOWS_PHONE should not be available"


### PR DESCRIPTION
Also fixed up some of the documentation issues in the new UWP macros.