### PR TITLE
Platform detection for CloudABI and cloudlibc (FOSS)

### DIFF
--- a/include/boost/predef/library/c.h
+++ b/include/boost/predef/library/c.h
@@ -12,6 +12,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/predef/library/c/_prefix.h>
 
+#include <boost/predef/library/c/cloudlibc.h>
 #include <boost/predef/library/c/gnu.h>
 #include <boost/predef/library/c/uc.h>
 #include <boost/predef/library/c/vms.h>

--- a/include/boost/predef/library/c/cloudlibc.h
+++ b/include/boost/predef/library/c/cloudlibc.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 James E. King, III
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ *   http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_PREDEF_LIBRARY_C_CLOUDLIBC_H
+#define BOOST_PREDEF_LIBRARY_C_CLOUDLIBC_H
+
+#include <boost/predef/version_number.h>
+#include <boost/predef/make.h>
+
+#include <boost/predef/library/c/_prefix.h>
+
+#if defined(__CloudABI__)
+#include <stddef.h>
+#endif
+
+/*`
+[heading `BOOST_LIB_C_CLOUDABI`]
+
+[@https://github.com/NuxiNL/cloudlibc cloudlibc] - CloudABI's standard C library.
+Version number available as major, and minor.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__cloudlibc__`] [__predef_detection__]]
+
+    [[`__cloudlibc_major__`, `__cloudlibc_minor__`] [V.R.0]]
+    ]
+ */
+
+#define BOOST_LIB_C_CLOUDABI BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if defined(__cloudlibc__)
+#   undef BOOST_LIB_C_CLOUDABI
+#   define BOOST_LIB_C_CLOUBABI \
+            BOOST_VERSION_NUMBER(__cloudlibc_major__,__cloudlibc_minor__,0)
+#endif
+
+#if BOOST_LIB_C_CLOUDABI
+#   define BOOST_LIB_C_CLOUDABI_AVAILABLE
+#endif
+
+#define BOOST_LIB_C_CLOUDABI_NAME "cloudlibc"
+
+#endif
+
+#include <boost/predef/detail/test.h>
+BOOST_PREDEF_DECLARE_TEST(BOOST_LIB_C_CLOUDABI,BOOST_LIB_C_CLOUDABI_NAME)

--- a/include/boost/predef/platform.h
+++ b/include/boost/predef/platform.h
@@ -11,6 +11,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 #define BOOST_PREDEF_PLATFORM_H
 #endif
 
+#include <boost/predef/platform/cloudabi.h>
 #include <boost/predef/platform/mingw.h>
 #include <boost/predef/platform/mingw32.h>
 #include <boost/predef/platform/mingw64.h>

--- a/include/boost/predef/platform/cloudabi.h
+++ b/include/boost/predef/platform/cloudabi.h
@@ -1,0 +1,43 @@
+/*
+  Copyright 2017 James E. King, III
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_PREDEF_PLAT_CLOUDABI_H
+#define BOOST_PREDEF_PLAT_CLOUDABI_H
+
+#include <boost/predef/version_number.h>
+#include <boost/predef/make.h>
+
+/*`
+[heading `BOOST_PLAT_CLOUDABI`]
+
+[@https://github.com/NuxiNL/cloudabi CloudABI] platform.
+
+[table
+    [[__predef_symbol__] [__predef_version__]]
+
+    [[`__CloudABI__`] [__predef_detection__]]
+    ]
+ */
+
+#define BOOST_PLAT_CLOUDABI BOOST_VERSION_NUMBER_NOT_AVAILABLE
+
+#if defined(__CloudABI__)
+#   undef BOOST_PLAT_CLOUDABI
+#   define BOOST_PLAT_CLOUDABI BOOST_VERSION_NUMBER_AVAILABLE
+#endif
+
+#if BOOST_PLAT_CLOUDABI
+#   define BOOST_PLAT_CLOUDABI_AVAILABLE
+#   include <boost/predef/detail/platform_detected.h>
+#endif
+
+#define BOOST_PLAT_CLOUDABI_NAME "CloudABI"
+
+#endif
+
+#include <boost/predef/detail/test.h>
+BOOST_PREDEF_DECLARE_TEST(BOOST_PLAT_CLOUDABI,BOOST_PLAT_CLOUDABI_NAME)


### PR DESCRIPTION
Currently this is binary without any versioning information.
Once I get more information about versioning I will add it later.
See: https://github.com/NuxiNL/cloudabi/issues/3

I set up the cross-compile environment and was able to get `info_as_c` to indicate the platform was `BOOST_PLAT_CLOUDABI`.

Adds: `BOOST_PLAT_CLOUDABI` (not versioned) and `BOOST_LIB_C_CLOUDABI` with major and minor version based off https://github.com/NuxiNL/cloudlibc/commit/20e1f13abe2582d9126075a4a4e0b0971d105be8.