### PR TITLE
CloudABI fixups

### DIFF
--- a/include/boost/predef/library/c.h
+++ b/include/boost/predef/library/c.h
@@ -12,7 +12,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #include <boost/predef/library/c/_prefix.h>
 
-#include <boost/predef/library/c/cloudlibc.h>
+#include <boost/predef/library/c/cloudabi.h>
 #include <boost/predef/library/c/gnu.h>
 #include <boost/predef/library/c/uc.h>
 #include <boost/predef/library/c/vms.h>

--- a/include/boost/predef/library/c/cloudabi.h
+++ b/include/boost/predef/library/c/cloudabi.h
@@ -1,13 +1,13 @@
 /*
- * Copyright (C) 2017 James E. King, III
+ * Copyright (C) 2017 James E. King III
  *
  * Distributed under the Boost Software License, Version 1.0.
  * (See accompanying file LICENSE_1_0.txt or copy at
  *   http://www.boost.org/LICENSE_1_0.txt)
  */
 
-#ifndef BOOST_PREDEF_LIBRARY_C_CLOUDLIBC_H
-#define BOOST_PREDEF_LIBRARY_C_CLOUDLIBC_H
+#ifndef BOOST_PREDEF_LIBRARY_C_CLOUDABI_H
+#define BOOST_PREDEF_LIBRARY_C_CLOUDABI_H
 
 #include <boost/predef/version_number.h>
 #include <boost/predef/make.h>
@@ -37,7 +37,7 @@ Version number available as major, and minor.
 
 #if defined(__cloudlibc__)
 #   undef BOOST_LIB_C_CLOUDABI
-#   define BOOST_LIB_C_CLOUBABI \
+#   define BOOST_LIB_C_CLOUDABI \
             BOOST_VERSION_NUMBER(__cloudlibc_major__,__cloudlibc_minor__,0)
 #endif
 


### PR DESCRIPTION
CloudABI support hasn't reached a release yet, and I have a couple fixups - one typo fix and one to align the filenames with the macros for cloudlibc.  This is based on actual use, getting Boost.Uuid to build under CloudABI with cloudlibc.