### PR TITLE
architecture: add support for __ARM_ARCH macro

### DIFF
--- a/include/boost/predef/architecture/arm.h
+++ b/include/boost/predef/architecture/arm.h
@@ -32,6 +32,7 @@ http://www.boost.org/LICENSE_1_0.txt)
     [[`__arm64`] [8.0.0]]
     [[`__TARGET_ARCH_ARM`] [V.0.0]]
     [[`__TARGET_ARCH_THUMB`] [V.0.0]]
+    [[`__ARM_ARCH`] [V.0.0]]
     [[`_M_ARM`] [V.0.0]]
     [[`_M_ARM64`] [8.0.0]]
     ]
@@ -41,6 +42,7 @@ http://www.boost.org/LICENSE_1_0.txt)
 
 #if defined(__arm__) || defined(__arm64) || defined(__thumb__) || \
     defined(__TARGET_ARCH_ARM) || defined(__TARGET_ARCH_THUMB) || \
+    defined(__ARM_ARCH) || \
     defined(_M_ARM) || defined(_M_ARM64)
 #   undef BOOST_ARCH_ARM
 #   if !defined(BOOST_ARCH_ARM) && defined(__arm64)
@@ -51,6 +53,9 @@ http://www.boost.org/LICENSE_1_0.txt)
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && defined(__TARGET_ARCH_THUMB)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(__TARGET_ARCH_THUMB,0,0)
+#   endif
+#   if !defined(BOOST_ARCH_ARM) && defined(__ARM_ARCH)
+#       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(__ARM_ARCH,0,0)
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && defined(_M_ARM64)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(8,0,0)


### PR DESCRIPTION
gcc-6 defines __ARM_ARCH

for the record: the following macros are defined:
```
#define __ARM_SIZEOF_WCHAR_T 4
#define __ARM_FEATURE_UNALIGNED 1
#define __ARM_FEATURE_IDIV 1
#define __ARM_FP 14
#define __ARM_ALIGN_MAX_STACK_PWR 16
#define __ARM_SIZEOF_MINIMAL_ENUM 4
#define __ARM_ALIGN_MAX_PWR 28
#define __ARM_FP16_FORMAT_IEEE 1
#define __ARM_FP16_ARGS 1
#define __ARM_FEATURE_FMA 1
#define __ARM_64BIT_STATE 1
#define __ARM_ARCH_PROFILE 65
#define __ARM_PCS_AAPCS64 1
#define __ARM_FEATURE_CLZ 1
#define __ARM_ARCH 8
#define __ARM_ARCH_8A 1
#define __ARM_NEON 1
#define __ARM_FEATURE_NUMERIC_MAXMIN 1
#define __ARM_ARCH_ISA_A64 1
#define __aarch64__ 1
```
