### PR TITLE
Remove undefined BOOST_ARCH_AMD64

### DIFF
--- a/include/boost/predef/other/endian.h
+++ b/include/boost/predef/other/endian.h
@@ -148,8 +148,7 @@ information and acquired knowledge:
 #       undef BOOST_ENDIAN_BIG_BYTE
 #       define BOOST_ENDIAN_BIG_BYTE BOOST_VERSION_NUMBER_AVAILABLE
 #   endif
-#   if BOOST_ARCH_AMD64 || \
-        BOOST_ARCH_IA64 || \
+#   if BOOST_ARCH_IA64 || \
         BOOST_ARCH_X86 || \
         BOOST_ARCH_BLACKFIN
 #       undef BOOST_ENDIAN_LITTLE_BYTE


### PR DESCRIPTION
This PR fixes an instance of MSVC warning C4668 (undefined preprocessor macro) by removing a reference to BOOST_ARCH_AMD64. This symbol has not been defined since commit b10e349.