### PR TITLE
os/linux: add more linux detection defines.

### DIFF
--- a/include/boost/predef/os/linux.h
+++ b/include/boost/predef/os/linux.h
@@ -21,13 +21,16 @@ http://www.boost.org/LICENSE_1_0.txt)
 
     [[`linux`] [__predef_detection__]]
     [[`__linux`] [__predef_detection__]]
+    [[`__linux__`] [__predef_detection__]]
+    [[`__gnu_linux__`] [__predef_detection__]]
     ]
  */
 
 #define BOOST_OS_LINUX BOOST_VERSION_NUMBER_NOT_AVAILABLE
 
 #if !defined(BOOST_PREDEF_DETAIL_OS_DETECTED) && ( \
-    defined(linux) || defined(__linux) \
+    defined(linux) || defined(__linux) || \
+    defined(__linux__) || defined(__gnu_linux__) \
     )
 #   undef BOOST_OS_LINUX
 #   define BOOST_OS_LINUX BOOST_VERSION_NUMBER_AVAILABLE


### PR DESCRIPTION
Some releases of g++, on some platforms, whilst running under some
standards, may not define neither linux, nor __linux. Add detections
for __linux__ and __gnu_linux__ for robustness.