### PR TITLE
Add support for build2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ boost-build.jam
 project-config.jam
 *.pyc
 .vscode/settings.json
+
+# build2 entries.
+#
+.bdep/

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,3 @@
+config.build
+root/
+bootstrap/

--- a/build/bootstrap.build
+++ b/build/bootstrap.build
@@ -1,0 +1,12 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+project = libboost-predef
+
+using version
+using config
+using test
+using install
+using dist

--- a/build/export.build
+++ b/build/export.build
@@ -1,0 +1,14 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+# Export stub: load the buildfile from include/ and export the library
+# target.
+#
+$out_root/
+{
+  include include/
+}
+
+export $out_root/include/$import.target

--- a/build/root.build
+++ b/build/root.build
@@ -1,0 +1,18 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+using c
+
+h{*}: extension = h
+
+cxx.std = latest
+
+using cxx
+
+hxx{*}: extension = hpp
+
+# The test target for cross-testing (running tests under Wine, etc).
+#
+test.target = $cxx.target

--- a/buildfile
+++ b/buildfile
@@ -1,0 +1,10 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+./: include/ test/ manifest
+
+# Don't install tests.
+#
+test/: install = false

--- a/include/buildfile
+++ b/include/buildfile
@@ -1,0 +1,21 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+# For a library with source code this will normally be in src/. For a header-
+# only library, include/ feels like a natural alternative.
+#
+lib{boost_predef}: {h hxx}{**}
+
+# Build options.
+#
+cxx.poptions =+ "-I$src_base"
+
+# Export options.
+#
+lib{boost_predef}: cxx.export.poptions = "-I$src_base"
+
+# Install headers recreating subdirectories.
+#
+{h hxx}{*}: install.subdirs = true

--- a/manifest
+++ b/manifest
@@ -1,0 +1,17 @@
+: 1
+name: libboost-predef
+project: libboost
+version: 1.9.0
+summary: Boost Predef C++ library
+license: Boost Software License v1.0
+url: https://github.com/boostorg/predef/
+email: grafikrobot@gmail.com
+description: \
+This library defines a set of compiler, architecture, operating system,
+library, and other version numbers from the information it can gather of C,
+C++, Objective C, and Objective C++ predefined macros or those defined in
+generally available headers.
+\
+builds: all
+depends: * build2 >= 0.9.0-
+depends: * bpkg >= 0.9.0-

--- a/test/build/.gitignore
+++ b/test/build/.gitignore
@@ -1,0 +1,3 @@
+config.build
+root/
+bootstrap/

--- a/test/build/bootstrap.build
+++ b/test/build/bootstrap.build
@@ -1,0 +1,10 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+project = # Unnamed test subproject.
+
+using config
+using test
+using dist

--- a/test/build/root.build
+++ b/test/build/root.build
@@ -1,0 +1,24 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+using c
+
+h{*}: extension = h
+c{*}: extension = c
+
+cxx.std = latest
+
+using cxx
+
+hxx{*}: extension = hpp
+cxx{*}: extension = cpp
+
+# Every exe{} in this subproject is by default a test.
+#
+exe{*}: test = true
+
+# The test target for cross-testing (running tests under Wine, etc).
+#
+test.target = $cxx.target

--- a/test/buildfile
+++ b/test/buildfile
@@ -1,0 +1,44 @@
+# Copyright Boris Kolpackov 2019
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+import libs = libboost-predef%lib{boost_predef}
+
+# Run tests.
+#
+for t: info_as_c info_as_cpp check_value make tested_at version workaround
+{
+  # Note that some of them are C and some C++. Rather than using separate
+  # loops, let's use the wildcard pattern machinery (without the wildcard) to
+  # pick the right prerequisite type.
+  #
+  ./: exe{$t}: {c cxx}{+$t} $libs
+}
+
+# Test-specific tweaks.
+#
+obj{check_value}: cxx.poptions += -DCHECK_VALUE=true
+
+exe{info_as_c info_as_cpp}: h{predef_info}
+
+# Compile tests.
+#
+# Note: the expected-to-fail tested_at_outdated is currently not handled; we
+# could probably do something ad hoc with a testscript but perhaps there
+# should be a better way.
+#
+./: obje{workaround_strict_config}: cxx{workaround_strict_config} $libs
+
+# Windows-specific tests.
+#
+./: obje{platform_windows}: include = ($cxx.target.class == 'windows')
+
+obje{platform_windows}: cxx{platform_windows} $libs
+
+# Mac OS-specific tests.
+#
+./: obje{macos_endian macos_vs_bsd}: include = ($c.target.class == 'macos')
+
+obje{macos_endian}: c{macos_endian} $libs
+obje{macos_vs_bsd}: c{macos_vs_bsd} $libs


### PR DESCRIPTION
This patch make the library a `build2` package. It includes support for building and running tests. CI results:

https://ci.stage.build2.org/?builds=libboost-predef

Notes:

- Using `build2` version from stage to take advantage of the latest features and fixes (the release is imminent).

- Package/library naming follows Debian packages (if changing, do it in manifest and `build/bootstrap.build`).

- Manifest may need tweaking (`url`, `email`, etc).

- Only minimum `.gitignore` entries. Can add the full set to support in-source builds.

If `build2` were the only build system...

- We could auto-generate the version headers with `manifest` becoming the only place where the version needs updating.

Let me know if there are any issues.