### PR TITLE
Architecture word bits predefs

### DIFF
--- a/include/boost/predef/architecture/alpha.h
+++ b/include/boost/predef/architecture/alpha.h
@@ -53,6 +53,7 @@ http://en.wikipedia.org/wiki/DEC_Alpha[DEC Alpha] architecture.
 #endif
 
 #define BOOST_ARCH_ALPHA_NAME "DEC Alpha"
+#define BOOST_ARCH_ALPHA_WORD_BITS 64
 
 #endif
 

--- a/include/boost/predef/architecture/arm.h
+++ b/include/boost/predef/architecture/arm.h
@@ -98,24 +98,29 @@ http://en.wikipedia.org/wiki/ARM_architecture[ARM] architecture.
         defined(__arm64) || defined(_M_ARM64) || defined(__aarch64__) || \
         defined(__AARCH64EL__) )
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(8,0,0)
+#       define BOOST_ARCH_ARM_WORD_BITS 64
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && ( \
     defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || \
     defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__) )
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(7,0,0)
+#       define BOOST_ARCH_ARM_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && ( \
     defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || \
     defined(__ARM_ARCH_6KZ__) || defined(__ARM_ARCH_6T2__) )
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(6,0,0)
+#       define BOOST_ARCH_ARM_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && ( \
     defined(__ARM_ARCH_5TE__) || defined(__ARM_ARCH_5TEJ__) )
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(5,0,0)
+#       define BOOST_ARCH_ARM_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_ARM) && ( \
     defined(__ARM_ARCH_4T__) || defined(__ARM_ARCH_4__) )
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER(4,0,0)
+#       define BOOST_ARCH_ARM_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_ARM)
 #       define BOOST_ARCH_ARM BOOST_VERSION_NUMBER_AVAILABLE

--- a/include/boost/predef/architecture/blackfin.h
+++ b/include/boost/predef/architecture/blackfin.h
@@ -40,6 +40,7 @@ Blackfin Processors from Analog Devices.
 #endif
 
 #define BOOST_ARCH_BLACKFIN_NAME "Blackfin"
+#define BOOST_ARCH_BLACKFIN_WORD_BITS 16
 
 #endif
 

--- a/include/boost/predef/architecture/convex.h
+++ b/include/boost/predef/architecture/convex.h
@@ -60,6 +60,8 @@ http://en.wikipedia.org/wiki/Convex_Computer[Convex Computer] architecture.
 
 #define BOOST_ARCH_CONVEX_NAME "Convex Computer"
 
+#define BOOST_ARCH_CONVEX_WORD_BITS 32
+
 #endif
 
 #include <boost/predef/detail/test.h>

--- a/include/boost/predef/architecture/ia64.h
+++ b/include/boost/predef/architecture/ia64.h
@@ -43,6 +43,7 @@ http://en.wikipedia.org/wiki/Ia64[Intel Itanium 64] architecture.
 #endif
 
 #define BOOST_ARCH_IA64_NAME "Intel Itanium 64"
+#define BOOST_ARCH_IA64_WORD_BITS 64
 
 #endif
 

--- a/include/boost/predef/architecture/m68k.h
+++ b/include/boost/predef/architecture/m68k.h
@@ -76,6 +76,7 @@ http://en.wikipedia.org/wiki/M68k[Motorola 68k] architecture.
 #endif
 
 #define BOOST_ARCH_M68K_NAME "Motorola 68k"
+#define BOOST_ARCH_M68K_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/mips.h
+++ b/include/boost/predef/architecture/mips.h
@@ -47,15 +47,19 @@ http://en.wikipedia.org/wiki/MIPS_architecture[MIPS] architecture.
 #   endif
 #   if !defined(BOOST_ARCH_MIPS) && (defined(_MIPS_ISA_MIPS1) || defined(_R3000))
 #       define BOOST_ARCH_MIPS BOOST_VERSION_NUMBER(1,0,0)
+#       define BOOST_ARCH_MIPS_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_MIPS) && (defined(_MIPS_ISA_MIPS2) || defined(__MIPS_ISA2__) || defined(_R4000))
 #       define BOOST_ARCH_MIPS BOOST_VERSION_NUMBER(2,0,0)
+#       define BOOST_ARCH_MIPS_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_MIPS) && (defined(_MIPS_ISA_MIPS3) || defined(__MIPS_ISA3__))
 #       define BOOST_ARCH_MIPS BOOST_VERSION_NUMBER(3,0,0)
+#       define BOOST_ARCH_MIPS_WORD_BITS 64
 #   endif
 #   if !defined(BOOST_ARCH_MIPS) && (defined(_MIPS_ISA_MIPS4) || defined(__MIPS_ISA4__))
 #       define BOOST_ARCH_MIPS BOOST_VERSION_NUMBER(4,0,0)
+#       define BOOST_ARCH_MIPS_WORD_BITS 64
 #   endif
 #   if !defined(BOOST_ARCH_MIPS)
 #       define BOOST_ARCH_MIPS BOOST_VERSION_NUMBER_AVAILABLE

--- a/include/boost/predef/architecture/parisc.h
+++ b/include/boost/predef/architecture/parisc.h
@@ -58,7 +58,7 @@ http://en.wikipedia.org/wiki/PA-RISC_family[HP/PA RISC] architecture.
 #endif
 
 #define BOOST_ARCH_PARISC_NAME "HP/PA RISC"
-#define BOOST_ARCH_PARISC_NAME 32
+#define BOOST_ARCH_PARISC_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/parisc.h
+++ b/include/boost/predef/architecture/parisc.h
@@ -58,6 +58,7 @@ http://en.wikipedia.org/wiki/PA-RISC_family[HP/PA RISC] architecture.
 #endif
 
 #define BOOST_ARCH_PARISC_NAME "HP/PA RISC"
+#define BOOST_ARCH_PARISC_NAME 32
 
 #endif
 

--- a/include/boost/predef/architecture/ppc.h
+++ b/include/boost/predef/architecture/ppc.h
@@ -49,12 +49,15 @@ http://en.wikipedia.org/wiki/PowerPC[PowerPC] architecture.
 #   undef BOOST_ARCH_PPC
 #   if !defined (BOOST_ARCH_PPC) && (defined(__ppc601__) || defined(_ARCH_601))
 #       define BOOST_ARCH_PPC BOOST_VERSION_NUMBER(6,1,0)
+#       define BOOST_ARCH_PPC_WORD_BITS 32
 #   endif
 #   if !defined (BOOST_ARCH_PPC) && (defined(__ppc603__) || defined(_ARCH_603))
 #       define BOOST_ARCH_PPC BOOST_VERSION_NUMBER(6,3,0)
+#       define BOOST_ARCH_PPC_WORD_BITS 32
 #   endif
 #   if !defined (BOOST_ARCH_PPC) && (defined(__ppc604__) || defined(__ppc604__))
 #       define BOOST_ARCH_PPC BOOST_VERSION_NUMBER(6,4,0)
+#       define BOOST_ARCH_PPC_WORD_BITS 32
 #   endif
 #   if !defined (BOOST_ARCH_PPC)
 #       define BOOST_ARCH_PPC BOOST_VERSION_NUMBER_AVAILABLE

--- a/include/boost/predef/architecture/ptx.h
+++ b/include/boost/predef/architecture/ptx.h
@@ -38,6 +38,7 @@ https://en.wikipedia.org/wiki/Parallel_Thread_Execution[PTX] architecture.
 #endif
 
 #define BOOST_ARCH_PTX_NAME "PTX"
+#define BOOST_ARCH_PTX_WORD_BITS 64
 
 #endif
 

--- a/include/boost/predef/architecture/pyramid.h
+++ b/include/boost/predef/architecture/pyramid.h
@@ -36,6 +36,7 @@ Pyramid 9810 architecture.
 #endif
 
 #define BOOST_ARCH_PYRAMID_NAME "Pyramid 9810"
+#define BOOST_ARCH_PYRAMID_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/riscv.h
+++ b/include/boost/predef/architecture/riscv.h
@@ -36,6 +36,7 @@ http://en.wikipedia.org/wiki/RISC-V[RISC-V] architecture.
 #endif
 
 #define BOOST_ARCH_RISCV_NAME "RISC-V"
+#define BOOST_ARCH_RISCV_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/rs6k.h
+++ b/include/boost/predef/architecture/rs6k.h
@@ -50,7 +50,7 @@ http://en.wikipedia.org/wiki/RS/6000[RS/6000] architecture.
 #endif
 
 #define BOOST_ARCH_PWR_NAME BOOST_ARCH_RS6000_NAME
-#definf BOOST_ARCH_PWR_WORD_BITS 32
+#define BOOST_ARCH_PWR_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/rs6k.h
+++ b/include/boost/predef/architecture/rs6k.h
@@ -50,6 +50,7 @@ http://en.wikipedia.org/wiki/RS/6000[RS/6000] architecture.
 #endif
 
 #define BOOST_ARCH_PWR_NAME BOOST_ARCH_RS6000_NAME
+#definf BOOST_ARCH_PWR_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/sparc.h
+++ b/include/boost/predef/architecture/sparc.h
@@ -34,9 +34,11 @@ http://en.wikipedia.org/wiki/SPARC[SPARC] architecture.
 #   undef BOOST_ARCH_SPARC
 #   if !defined(BOOST_ARCH_SPARC) && defined(__sparcv9)
 #       define BOOST_ARCH_SPARC BOOST_VERSION_NUMBER(9,0,0)
+#       define BOOST_ARCH_SPARC_WORD_BITS 64
 #   endif
 #   if !defined(BOOST_ARCH_SPARC) && defined(__sparcv8)
 #       define BOOST_ARCH_SPARC BOOST_VERSION_NUMBER(8,0,0)
+#       define BOOST_ARCH_SPARC_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_SPARC)
 #       define BOOST_ARCH_SPARC BOOST_VERSION_NUMBER_AVAILABLE

--- a/include/boost/predef/architecture/superh.h
+++ b/include/boost/predef/architecture/superh.h
@@ -38,18 +38,23 @@ If available versions [1-5] are specifically detected.
 #   undef BOOST_ARCH_SH
 #   if !defined(BOOST_ARCH_SH) && (defined(__SH5__))
 #       define BOOST_ARCH_SH BOOST_VERSION_NUMBER(5,0,0)
+#       define BOOST_ARCH_SH_WORD_BITS 64
 #   endif
 #   if !defined(BOOST_ARCH_SH) && (defined(__SH4__))
 #       define BOOST_ARCH_SH BOOST_VERSION_NUMBER(4,0,0)
+#       define BOOST_ARCH_SH_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_SH) && (defined(__sh3__) || defined(__SH3__))
 #       define BOOST_ARCH_SH BOOST_VERSION_NUMBER(3,0,0)
+#       define BOOST_ARCH_SH_WORD_BITS 32
 #   endif
 #   if !defined(BOOST_ARCH_SH) && (defined(__sh2__))
 #       define BOOST_ARCH_SH BOOST_VERSION_NUMBER(2,0,0)
+#       define BOOST_ARCH_SH_WORD_BITS 16
 #   endif
 #   if !defined(BOOST_ARCH_SH) && (defined(__sh1__))
 #       define BOOST_ARCH_SH BOOST_VERSION_NUMBER(1,0,0)
+#       define BOOST_ARCH_SH_WORD_BITS 16
 #   endif
 #   if !defined(BOOST_ARCH_SH)
 #       define BOOST_ARCH_SH BOOST_VERSION_NUMBER_AVAILABLE

--- a/include/boost/predef/architecture/sys370.h
+++ b/include/boost/predef/architecture/sys370.h
@@ -37,6 +37,7 @@ http://en.wikipedia.org/wiki/System/370[System/370] architecture.
 #endif
 
 #define BOOST_ARCH_SYS370_NAME "System/370"
+#define BOOST_ARCH_SYS370_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/sys390.h
+++ b/include/boost/predef/architecture/sys390.h
@@ -37,6 +37,7 @@ http://en.wikipedia.org/wiki/System/390[System/390] architecture.
 #endif
 
 #define BOOST_ARCH_SYS390_NAME "System/390"
+#define BOOST_ARCH_SYS390_WORD_BITS 32
 
 #endif
 

--- a/include/boost/predef/architecture/x86/32.h
+++ b/include/boost/predef/architecture/x86/32.h
@@ -79,6 +79,7 @@ If available versions [3-6] are specifically detected.
 #endif
 
 #define BOOST_ARCH_X86_32_NAME "Intel x86-32"
+#define BOOST_ARCH_X86_32_WORD_BITS 32
 
 #include <boost/predef/architecture/x86.h>
 

--- a/include/boost/predef/architecture/x86/64.h
+++ b/include/boost/predef/architecture/x86/64.h
@@ -42,6 +42,7 @@ http://en.wikipedia.org/wiki/Ia64[Intel IA-64] architecture.
 #endif
 
 #define BOOST_ARCH_X86_64_NAME "Intel x86-64"
+#define BOOST_ARCH_X86_64_WORD_BITS 64
 
 #include <boost/predef/architecture/x86.h>
 

--- a/include/boost/predef/architecture/z.h
+++ b/include/boost/predef/architecture/z.h
@@ -36,6 +36,7 @@ http://en.wikipedia.org/wiki/Z/Architecture[z/Architecture] architecture.
 #endif
 
 #define BOOST_ARCH_Z_NAME "z/Architecture"
+#define BOOST_ARCH_Z_WORD_BITS 64
 
 #endif
 


### PR DESCRIPTION
Each architecture has pre-defined word size in bits. Since this has no way to be detected correctly from compiler-only definitions (and `sizeof(int)` is obviously not the way as well), pre-defining according to the each architecture's documentation is the only way. So, here it is.

Resolves https://github.com/NilFoundation/predef/issues/2.