### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,6 @@
 # See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt
 
-# NOTE:
-#   CMake support for Boost.Predef is currently experimental at best and the
-#   interface is likely to change in the future
-#
 # This file provides minimal cmake support (no unit-tests,
 # no installation) for integration into a "host" cmake project
 # via the "add_subdirectory( <path-to-boost-predef> )" command.
@@ -20,12 +16,12 @@
 
 # Only need the basic minimum of project, add_library, and
 # target_include_directories commands.
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.5 )
 
-# Don't set VERSION, as that's a pita to keep up to date with the version
-# header. And don't set LANGUAGES as we are multi-language and header
-# only, so it's irrelevant.
-project( BoostPredef LANGUAGES NONE )
+# VERSION is set to the Boost superproject version if present,
+# otherwise none. LANGUAGES are set to NONE as we are multi-language
+# and preprocessor-only.
+project( boost_predef VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES NONE )
 
 # Simple INTERFACE, and header only, library target.
 add_library( boost_predef INTERFACE )


### PR DESCRIPTION
* Remove obsolete comment
* Bump minimum version to 3.5 to avoid the annoying CMake warning
```
CMake Deprecation Warning at /Users/runner/work/system/boost-root/libs/predef/CMakeLists.txt:23 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
* Use project name `boost_predef` as this is the Boost convention
* Use `VERSION "${BOOST_SUPERPROJECT_VERSION}"` per Boost convention. This sets the project version to the Boost version if the library is part of the Boost superproject, and otherwise leaves it empty, as before
* Update comment to reflect changes